### PR TITLE
fix: link to the new repository

### DIFF
--- a/src/routes/BrowserWarning.svelte
+++ b/src/routes/BrowserWarning.svelte
@@ -17,7 +17,7 @@
     >{$LL.browserWarning.INFO_BROWSER_SUFFIX()}
   </p>
   <div>
-    <a href="https://github.com/Theaninova/dotio/releases" target="_blank"
+    <a href="https://github.com/CharaChorder/DeviceManager/releases" target="_blank"
       >{$LL.browserWarning.DOWNLOAD_APP()}</a
     >
   </div>


### PR DESCRIPTION
The old repo will soon fall behind in terms of releases and the link will become outdated.

NOTE: This should only be merged once you guys actually release stuff here since everything is just tags at the moment.