### PR TITLE
[#169] Fix autoConnect feature. 

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -17,7 +17,6 @@ export function persistentWritable<T>(
           : writable(value);
     } catch (e) {
       console.error(e);
-    } finally {
       store = writable(value);
     }
     store.subscribe((value) => {


### PR DESCRIPTION
Use value from persistent storage when it is available.

Initial code overrides storage and sets it to default regardless of values stored in persistent storage.

Removing `finally` block allows to set values as default in case of exception (catch block) and restore from persistent storage when available 