### PR TITLE
Quick add of arrow action in the chord

### DIFF
--- a/src/routes/(app)/config/chords/ChordPhraseEdit.svelte
+++ b/src/routes/(app)/config/chords/ChordPhraseEdit.svelte
@@ -18,11 +18,11 @@
   });
 
   function keypress(event: KeyboardEvent) {
-    if (event.key === "ArrowUp") {
+    if (!event.shiftKey && event.key === "ArrowUp") {
       addSpecial(event);
-    } else if (event.key === "ArrowLeft") {
+    } else if (!event.shiftKey && event.key === "ArrowLeft") {
       moveCursor(cursorPosition - 1);
-    } else if (event.key === "ArrowRight") {
+    } else if (!event.shiftKey && event.key === "ArrowRight") {
       moveCursor(cursorPosition + 1);
     } else if (event.key === "Backspace") {
       deleteAction(cursorPosition - 1);


### PR DESCRIPTION
### Fast editing arrows in chords
1. Added a flag to allow adding arrows (left, up, right) directly when editing the chord using shift+up/left/right (shift is ignored as an input anyways, but for someone like me using chords with arrows a lot it is a huge usability improvement).
