### PR TITLE
Remove unused `direction` with incomplete type definition.

### DIFF
--- a/src/lib/PageTransition.svelte
+++ b/src/lib/PageTransition.svelte
@@ -4,7 +4,7 @@
   import { expoIn, expoOut } from "svelte/easing";
   import type { Snippet } from "svelte";
 
-  let { children, routeOrder }: { children: Snippet; routeOrder: string[]; direction: } =
+  let { children, routeOrder }: { children: Snippet; routeOrder: string[] } =
     $props();
 
   let inDirection = $state(0);


### PR DESCRIPTION
Removing unused `direction` with incomplete type definition causing incorrect syntax issue